### PR TITLE
Changed cSFS starting point to make for fair comparison

### DIFF
--- a/lib/est2d.py
+++ b/lib/est2d.py
@@ -157,8 +157,8 @@ def cSFS2D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, 
         cholDict = dict()
         for k in np.arange(len(nraneffs)):
 
-            cholDict[k] = vechTri2mat2D(init_paramVector[FishIndsDk[k]:FishIndsDk[k+1]])
-            Ddict[k] = cholDict[k] @ cholDict[k].transpose()
+            Ddict[k] = makeDpd2D(initDk2D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict))
+            cholDict[k] = np.linalg.cholesky(Ddict[k])
         
         # Matrix version
         D = scipy.sparse.lil_matrix((q,q))

--- a/lib/npMatrix2d.py
+++ b/lib/npMatrix2d.py
@@ -1029,7 +1029,7 @@ def initDk2D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict):
 def makeDnnd2D(D):
   
   # Check if we have negative eigenvalues
-  if not np.all(np.linalg.eigvals(D)>0):
+  if not np.all(np.linalg.eigvals(D)>=0):
   
     # If we have negative eigenvalues
     eigvals,eigvecs = np.linalg.eigh(D)
@@ -1047,6 +1047,61 @@ def makeDnnd2D(D):
     
   return(D_nnd)
 
+# ============================================================================
+#
+# The below function takes in a covariance matrix D and finds a projection of 
+# it onto the space of positive definite matrices D_+'. It uses the following
+# method taken from Demidenko (2012), page 105:
+#
+# If D is has eigenvalue decomposition D=P\Lambda P' it's projection into D_+'
+# is defined by the matrix below:
+#
+# Dhat_+ = P\Lambda_+P'
+#
+# Where \Lambda_+ is defined by the elementwise maximum of \Lambda and 0; i.e.
+# \Lambda_+(i,j) = max(\Lambda_+(i,j),1e-6).
+#
+# Note: This is not to be confused with the generalized inverse of the
+# duplication matrix, also denoted with a D+.
+#
+# ----------------------------------------------------------------------------
+#
+# This function takes the following inputs:
+#
+# ----------------------------------------------------------------------------
+#
+# - `D`: A square symmetric matrix.
+#
+# ----------------------------------------------------------------------------
+#
+# It returns as outputs:
+#
+# ----------------------------------------------------------------------------
+#
+# - `D_nnd`: A projection of D onto the space of positive definite matrices 
+#            D_+.
+#
+# ============================================================================
+def makeDpd2D(D):
+  
+  # Check if we have negative or zero valued eigenvalues
+  if not np.all(np.linalg.eigvals(D)>0):
+  
+    # If we have negative eigenvalues
+    eigvals,eigvecs = np.linalg.eigh(D)
+    
+    # Work out elementwise max of lambda and 0
+    lamplus = np.diag(np.maximum(eigvals,1e-6))
+    
+    # Work out D+
+    D_pd = eigvecs @ lamplus @ np.linalg.inv(eigvecs)
+    
+  else:
+    
+    # D is already positive definite in this case
+    D_pd = D
+    
+  return(D_pd)
 
 # ============================================================================
 # This function returns the log likelihood of (\beta, \sigma^2, D) which is

--- a/test/Unit/npMatrix2d_tests.py
+++ b/test/Unit/npMatrix2d_tests.py
@@ -1146,6 +1146,39 @@ def test_makeDnnd2D():
 
 # =============================================================================
 #
+# The below function tests the function `makeDpd2D`. It does this by checking
+# the function against a predefined example.
+#
+# =============================================================================
+def test_makeDpd2D():
+
+    # Examples usecase
+    test = np.eye(5)
+    test[3,3]=-1
+
+    # Expected outcome
+    expected = np.eye(5)
+    expected[3,3]=1e-6
+
+    # Check if the function gives as expected
+    testVal = np.allclose(makeDpd2D(test),expected)
+
+    # Result
+    if testVal:
+        result = 'Passed'
+    else:
+        result = 'Failed'
+
+    print('=============================================================')
+    print('Unit test for: makeDpd2D')
+    print('-------------------------------------------------------------')
+    print('Result: ', result)
+
+    return(result)
+
+
+# =============================================================================
+#
 # The below function tests the function `llh2D`. It does this by simulating 
 # data and checks that the function behaves the same as niave calculation of 
 # the same quantity.
@@ -1865,6 +1898,16 @@ def run_all2D():
     # Test makeDnnd2D
     name = 'makeDnnd2D'
     result = test_makeDnnd2D()
+    # Add result to arrays.
+    if result=='Passed':
+        passedTests = np.append(passedTests, name)
+    if result=='Failed':
+        failedTests = np.append(failedTests, name)
+
+
+    # Test makeDpd2D
+    name = 'makeDpd2D'
+    result = test_makeDpd2D()
     # Add result to arrays.
     if result=='Passed':
         passedTests = np.append(passedTests, name)


### PR DESCRIPTION
This is a small PR which changes the starting point used for D in the `cSFS2D` algorithm to a starting point similar to that used for the other methods. As the cholesky decomposition is then performed on D, care had to be taken to ensure that D was positive definite (rather than non-negative definite) for this method, so that the `np.linalg.cholesky` function would not error.