### PR TITLE
Duplication matrix change

### DIFF
--- a/lib/est3d.py
+++ b/lib/est3d.py
@@ -115,10 +115,10 @@ def FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n):
     # ------------------------------------------------------------------------------
     # Duplication matrices
     # ------------------------------------------------------------------------------
-    invDupMatdict = dict()
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
 
-        invDupMatdict[i] = np.asarray(invDupMat2D(nraneffs[i]).todense())
+        dupMatTdict[i] = np.asarray(dupMat2D(nraneffs[i]).todense()).transpose()
         
     # ------------------------------------------------------------------------------
     # Inital D
@@ -127,7 +127,7 @@ def FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n):
     Ddict = dict()
     for k in np.arange(len(nraneffs)):
 
-        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict))
+        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, dupMatTdict))
     
     # Full version of D
     D = getDfromDict3D(Ddict, nraneffs, nlevels)
@@ -243,9 +243,9 @@ def FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n):
 
             # Calculate covariance between sigma2 and D
             if ZtZmatdict[k] is None:
-                covdldsigma2dD,ZtZmatdict[k] = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, ZtZmat=None)
+                covdldsigma2dD,ZtZmatdict[k] = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, ZtZmat=None)
             else:
-                covdldsigma2dD,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, ZtZmat=ZtZmatdict[k])
+                covdldsigma2dD,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, ZtZmat=ZtZmatdict[k])
 
             # Assign to the relevant block
             FisherInfoMat[:,p, FishIndsDk[k]:FishIndsDk[k+1]] = covdldsigma2dD.reshape(FisherInfoMat[:,p, FishIndsDk[k]:FishIndsDk[k+1]].shape)
@@ -263,9 +263,9 @@ def FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n):
                 # Calculate covariance of derivative with respect to D_k
                 #-----------------------------------------------------------------------
                 if permdict[str(k1)+str(k2)] is None:
-                    covdldDk1dDk2,permdict[str(k1)+str(k2)] = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, perm=None)
+                    covdldDk1dDk2,permdict[str(k1)+str(k2)] = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, perm=None)
                 else:
-                    covdldDk1dDk2,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, perm=permdict[str(k1)+str(k2)])
+                    covdldDk1dDk2,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, perm=permdict[str(k1)+str(k2)])
 
                 # Add to FImat
                 FisherInfoMat[np.ix_(np.arange(v_iter), IndsDk1, IndsDk2)] = covdldDk1dDk2
@@ -283,7 +283,7 @@ def FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n):
         for k in np.arange(len(nraneffs)):
 
             paramVector = np.concatenate((paramVector, mat2vech3D(Ddict[k])),axis=1)
-            derivVector = np.concatenate((derivVector, mat2vech3D(dldDdict[k])),axis=1)
+            derivVector = np.concatenate((derivVector, dupMatTdict[k] @ mat2vec3D(dldDdict[k])),axis=1)
         
         # --------------------------------------------------------------------------
         # Update step
@@ -501,10 +501,10 @@ def pFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
     # ------------------------------------------------------------------------------
     # Duplication matrices
     # ------------------------------------------------------------------------------
-    invDupMatdict = dict()
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
 
-        invDupMatdict[i] = np.asarray(invDupMat2D(nraneffs[i]).todense())
+        dupMatTdict[i] = np.asarray(dupMat2D(nraneffs[i]).todense()).transpose()
 
     # ------------------------------------------------------------------------------
     # Inital D
@@ -513,7 +513,7 @@ def pFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
     Ddict = dict()
     for k in np.arange(len(nraneffs)):
 
-        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict))
+        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, dupMatTdict))
     
     # Full version of D
     D = getDfromDict3D(Ddict, nraneffs, nlevels)
@@ -630,9 +630,9 @@ def pFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
 
             # Calculate covariance between sigma2 and D
             if ZtZmatdict[k] is None:
-                covdldsigma2dD,ZtZmatdict[k] = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, ZtZmat=None)
+                covdldsigma2dD,ZtZmatdict[k] = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, ZtZmat=None)
             else:
-                covdldsigma2dD,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, ZtZmat=ZtZmatdict[k])
+                covdldsigma2dD,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, ZtZmat=ZtZmatdict[k])
 
             # Assign to the relevant block
             FisherInfoMat[:,p, FishIndsDk[k]:FishIndsDk[k+1]] = covdldsigma2dD.reshape(FisherInfoMat[:,p, FishIndsDk[k]:FishIndsDk[k+1]].shape)
@@ -650,9 +650,9 @@ def pFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
                 # Calculate covariance of derivative with respect to D_k
                 #-----------------------------------------------------------------------
                 if permdict[str(k1)+str(k2)] is None:
-                    covdldDk1dDk2,permdict[str(k1)+str(k2)] = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, perm=None)
+                    covdldDk1dDk2,permdict[str(k1)+str(k2)] = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, perm=None)
                 else:
-                    covdldDk1dDk2,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, perm=permdict[str(k1)+str(k2)])
+                    covdldDk1dDk2,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, perm=permdict[str(k1)+str(k2)])
 
                 # Add to FImat
                 FisherInfoMat[np.ix_(np.arange(v_iter), IndsDk1, IndsDk2)] = covdldDk1dDk2
@@ -886,12 +886,10 @@ def SFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
     # ------------------------------------------------------------------------------
     # Duplication matrices
     # ------------------------------------------------------------------------------
-    invDupMatdict = dict()
-    dupInvDupMatdict = dict()
-    dupDuptMatdict = dict()
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
 
-        invDupMatdict[i] = np.asarray(invDupMat2D(nraneffs[i]).todense())
+        dupMatTdict[i] = np.asarray(dupMat2D(nraneffs[i]).todense()).transpose()
         
     # ------------------------------------------------------------------------------
     # Inital D
@@ -900,7 +898,7 @@ def SFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
     Ddict = dict()
     for k in np.arange(len(nraneffs)):
 
-        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict))
+        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, dupMatTdict))
     
     # Full version of D
     D = getDfromDict3D(Ddict, nraneffs, nlevels)
@@ -1022,14 +1020,14 @@ def SFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n)
             # Calculate covariance of derivative with respect to D_k
             #-----------------------------------------------------------------------
             if permdict[str(k)] is None:
-                covdldDk1dDk2,permdict[str(k)] = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, perm=None)
+                covdldDk1dDk2,permdict[str(k)] = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, perm=None)
             else:
-                covdldDk1dDk2,_ = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, perm=permdict[str(k)])
+                covdldDk1dDk2,_ = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, perm=permdict[str(k)])
 
             #-----------------------------------------------------------------------
             # Work out update amount
             #-----------------------------------------------------------------------
-            update = np.linalg.solve(forceSym3D(covdldDk1dDk2), mat2vech3D(dldDk))
+            update = np.linalg.solve(forceSym3D(covdldDk1dDk2), dupMatTdict[k] @ mat2vec3D(dldDk))
             
             # Multiply by stepsize
             update = np.einsum('i,ijk->ijk',lam, update)
@@ -1255,12 +1253,10 @@ def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, 
     # ------------------------------------------------------------------------------
     # Duplication matrices
     # ------------------------------------------------------------------------------
-    invDupMatdict = dict()
-    dupInvDupMatdict = dict()
-    dupDuptMatdict = dict()
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
 
-        invDupMatdict[i] = np.asarray(invDupMat2D(nraneffs[i]).todense())
+        dupMatTdict[i] = np.asarray(dupMat2D(nraneffs[i]).todense()).transpose()
         
     # ------------------------------------------------------------------------------
     # Inital D
@@ -1269,7 +1265,7 @@ def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, 
     Ddict = dict()
     for k in np.arange(len(nraneffs)):
 
-        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict))
+        Ddict[k] = makeDnnd3D(initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, dupMatTdict))
     
     # Full version of D
     D = getDfromDict3D(Ddict, nraneffs, nlevels)
@@ -1399,9 +1395,9 @@ def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, 
             # Calculate covariance of derivative with respect to D_k
             #-----------------------------------------------------------------------
             if permdict[str(k)] is None:
-                covdldDk1dDk2,permdict[str(k)] = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, perm=None)
+                covdldDk1dDk2,permdict[str(k)] = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, perm=None)
             else:
-                covdldDk1dDk2,_ = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, vec=True, perm=permdict[str(k)])
+                covdldDk1dDk2,_ = get_covdldDk1Dk23D(k, k, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, vec=True, perm=permdict[str(k)])
 
             #-----------------------------------------------------------------------
             # Work out update amount

--- a/test/Unit/est2d_tests.py
+++ b/test/Unit/est2d_tests.py
@@ -141,6 +141,8 @@ def test2D():
     llh = llh2D(n, ZtZ, Zte, ete, sigma2, DinvIplusZtZD,D)[0,0]-n/2*np.log(np.pi)
     results.at['llh','Truth']=llh
 
+    print('Truth Saved')
+
     #===============================================================================
     # pSFS
     #===============================================================================
@@ -170,6 +172,8 @@ def test2D():
     for i in np.arange(4+p,p+qu+4):
         results.at[indexVec[i+qu],'pSFS']=paramVector_pSFS[p,0]*paramVector_pSFS[i-3,0]
 
+    print('pSFS Saved')
+    
     #===============================================================================
     # PeLS
     #===============================================================================
@@ -247,6 +251,8 @@ def test2D():
             results.at[indexVec[Dinds[k]+j],'PeLS']=vechDk[j,0]/sigma2_pls[0]
             results.at[indexVec[Dinds[k]+qu+j],'PeLS']=vechDk[j,0]
 
+    print('PeLS Saved')
+    
     #===============================================================================
     # cSFS
     #===============================================================================
@@ -269,6 +275,8 @@ def test2D():
     for i in np.arange(4+p,p+qu+4):
         results.at[indexVec[i+qu],'cSFS']=paramVector_cSFS[p,0]*paramVector_cSFS[i-3,0]
         
+    print('cSFS Saved')
+    
     #===============================================================================
     # FS
     #===============================================================================
@@ -290,6 +298,8 @@ def test2D():
     # Record D*sigma2
     for i in np.arange(4+p,p+qu+4):
         results.at[indexVec[i+qu],'FS']=paramVector_FS[p,0]*paramVector_FS[i-3,0]
+
+    print('FS Saved')
 
     #===============================================================================
     # SFS
@@ -313,6 +323,8 @@ def test2D():
     for i in np.arange(4+p,p+qu+4):
         results.at[indexVec[i+qu],'SFS']=paramVector_SFS[p,0]*paramVector_SFS[i-3,0]
 
+    print('SFS Saved')
+    
     #===============================================================================
     # pFS
     #===============================================================================
@@ -335,8 +347,10 @@ def test2D():
     for i in np.arange(4+p,p+qu+4):
         results.at[indexVec[i+qu],'pFS']=paramVector_pFS[p,0]*paramVector_pFS[i-3,0]
 
+    print('pFS Saved')
+    
     # Print results
     print(results.to_string())
-
+    
     # Return results
     return(results)

--- a/test/Unit/npMatrix2d_tests.py
+++ b/test/Unit/npMatrix2d_tests.py
@@ -2255,8 +2255,11 @@ def test_get_dS22D():
             # K = Z_(k,j)'V^{-1}X(X'V^{-1})^{-1}L'
             K = ZkjtiVX @ np.linalg.inv(XtiVX) @ L.transpose()
             
+            # Duplication matrix transposed
+            dupMatT = dupMat2D(nraneffs[k]).transpose()
+            
             # Sum terms
-            dS2dvechDk = dS2dvechDk + mat2vech2D(np.kron(K,K.transpose()))
+            dS2dvechDk = dS2dvechDk + dupMatT @ mat2vec2D(np.kron(K,K.transpose()))
 
         # Multiply by sigma^2
         dS2dvechDk = sigma2*dS2dvechDk

--- a/test/Unit/npMatrix3d_tests.py
+++ b/test/Unit/npMatrix3d_tests.py
@@ -24,7 +24,7 @@ from genTestDat import prodMats3D, genTestData3D
 # file.
 #
 # Author: Tom Maullin
-# Last edited: 22/03/2020
+# Last edited: 22/03/2020su
 #
 # =============================================================================
 
@@ -477,11 +477,11 @@ def test_initDk3D():
     # Choose random voxel to check worked correctly
     testv = np.random.randint(0,v)
 
-    # Work out the inverse duplication matrices we need.
-    invDupMatdict = dict()
+    # Work out the transpose duplication matrices we need.
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
       
-      invDupMatdict[i] = invDupMat2D(nraneffs[i]).toarray()
+      dupMatTdict[i] = dupMat2D(nraneffs[i]).toarray().transpose()
 
     # Work out Z'e
     Zte = ZtY - ZtX @ beta
@@ -491,15 +491,15 @@ def test_initDk3D():
     k = np.random.randint(0,nraneffs.shape[0])
 
     # First test spatially varying
-    initDk_sv_test = initDk3D(k, ZtZ_sv, Zte_sv, sigma2, nlevels, nraneffs, invDupMatdict)[testv,:,:]
-    initDk_sv_expected = initDk2D(k, ZtZ_sv[testv,:,:], Zte_sv[testv,:,:], sigma2[testv], nlevels, nraneffs, invDupMatdict)
+    initDk_sv_test = initDk3D(k, ZtZ_sv, Zte_sv, sigma2, nlevels, nraneffs, dupMatTdict)[testv,:,:]
+    initDk_sv_expected = initDk2D(k, ZtZ_sv[testv,:,:], Zte_sv[testv,:,:], sigma2[testv], nlevels, nraneffs, dupMatTdict)
     
     # Check if results are all close.
     sv_testVal = np.allclose(initDk_sv_test,initDk_sv_expected)
 
     # Now test non spatially varying
-    initDk_nsv_test = initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, invDupMatdict)[testv,:,:]
-    initDk_nsv_expected = initDk2D(k, ZtZ[0,:,:], Zte[testv,:,:], sigma2[testv], nlevels, nraneffs, invDupMatdict)
+    initDk_nsv_test = initDk3D(k, ZtZ, Zte, sigma2, nlevels, nraneffs, dupMatTdict)[testv,:,:]
+    initDk_nsv_expected = initDk2D(k, ZtZ[0,:,:], Zte[testv,:,:], sigma2[testv], nlevels, nraneffs, dupMatTdict)
     
     # Check if results are all close.
     nsv_testVal = np.allclose(initDk_nsv_test,initDk_nsv_expected)
@@ -899,26 +899,26 @@ def test_get_covdldDkdsigma23D():
     # Decide on a random factor
     k = np.random.randint(0,nraneffs.shape[0])
 
-    # Work out the inverse duplication matrices we need.
-    invDupMatdict = dict()
+    # Work out the transpose duplication matrices we need.
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
       
-      invDupMatdict[i] = invDupMat2D(nraneffs[i]).toarray()
+      dupMatTdict[i] = dupMat2D(nraneffs[i]).toarray().transpose()
 
     # First test spatially varying
-    covdldDsigma2_sv_test,ZtZmat = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, invDupMatdict)
-    covdldDsigma2_sv_test,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, invDupMatdict, ZtZmat=ZtZmat)
+    covdldDsigma2_sv_test,ZtZmat = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, dupMatTdict)
+    covdldDsigma2_sv_test,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, dupMatTdict, ZtZmat=ZtZmat)
     covdldDsigma2_sv_test = covdldDsigma2_sv_test[testv,:,:]
-    covdldDsigma2_sv_expected,_ = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ_sv[testv,:,:], DinvIplusZtZD_sv[testv,:,:], invDupMatdict)
+    covdldDsigma2_sv_expected,_ = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ_sv[testv,:,:], DinvIplusZtZD_sv[testv,:,:], dupMatTdict)
 
     # Check if results are all close.
     sv_testVal = np.allclose(covdldDsigma2_sv_test,covdldDsigma2_sv_expected)
 
     # Now test non spatially varying
-    covdldDsigma2_nsv_test,ZtZmat = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict)
-    covdldDsigma2_nsv_test,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict, ZtZmat=ZtZmat)
+    covdldDsigma2_nsv_test,ZtZmat = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict)
+    covdldDsigma2_nsv_test,_ = get_covdldDkdsigma23D(k, sigma2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict, ZtZmat=ZtZmat)
     covdldDsigma2_nsv_test = covdldDsigma2_nsv_test[testv,:,:]
-    covdldDsigma2_nsv_expected,_ = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], invDupMatdict)
+    covdldDsigma2_nsv_expected,_ = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], dupMatTdict)
 
     # Check if results are all close.
     nsv_testVal = np.allclose(covdldDsigma2_nsv_test,covdldDsigma2_nsv_expected)
@@ -968,26 +968,26 @@ def test_get_covdldDk1Dk23D():
     k1 = np.random.randint(0,nraneffs.shape[0])
     k2 = np.random.randint(0,nraneffs.shape[0])
 
-    # Work out the inverse duplication matrices we need.
-    invDupMatdict = dict()
+    # Work out the transpose duplication matrices we need.
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
       
-      invDupMatdict[i] = invDupMat2D(nraneffs[i]).toarray()
+      dupMatTdict[i] = dupMat2D(nraneffs[i]).toarray().transpose()
 
     # First test spatially varying
-    covdldD_sv_test,perm = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, invDupMatdict)
-    covdldD_sv_test,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, invDupMatdict,perm=perm)
+    covdldD_sv_test,perm = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, dupMatTdict)
+    covdldD_sv_test,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ_sv, DinvIplusZtZD_sv, dupMatTdict,perm=perm)
     covdldD_sv_test = covdldD_sv_test[testv,:,:]
-    covdldD_sv_expected = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ_sv[testv,:,:], DinvIplusZtZD_sv[testv,:,:], invDupMatdict)[0]
+    covdldD_sv_expected = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ_sv[testv,:,:], DinvIplusZtZD_sv[testv,:,:], dupMatTdict)[0]
   
     # Check if results are all close.
     sv_testVal = np.allclose(covdldD_sv_test,covdldD_sv_expected)
 
     # Now test non spatially varying
-    covdldD_nsv_test,perm = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict)
-    covdldD_nsv_test,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, invDupMatdict)
+    covdldD_nsv_test,perm = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict)
+    covdldD_nsv_test,_ = get_covdldDk1Dk23D(k1, k2, nlevels, nraneffs, ZtZ, DinvIplusZtZD, dupMatTdict)
     covdldD_nsv_test = covdldD_nsv_test[testv,:,:]
-    covdldD_nsv_expected = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], invDupMatdict)[0]
+    covdldD_nsv_expected = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], dupMatTdict)[0]
     
     # Check if results are all close.
     nsv_testVal = np.allclose(covdldD_nsv_test,covdldD_nsv_expected)
@@ -1172,12 +1172,12 @@ def test_mat2vecb3D():
 def test_sumAijBijt3D():
 
     # Generate random matrix dimensions
-    v = np.random.randint(40,140)
+    v = np.random.randint(10,20)
     n1 = np.random.randint(2,10)
     n1prime = np.random.randint(2,10)
     n2 = np.random.randint(2,10)
-    l1 = np.random.randint(50,100)
-    l2 = np.random.randint(50,100)
+    l1 = np.random.randint(50,60)
+    l2 = np.random.randint(50,60)
 
     # Work out m1 and m2
     m1 = n1*l1
@@ -1220,11 +1220,11 @@ def test_sumAijBijt3D():
 def test_sumAijKronBij3D():
 
     # Generate random matrix dimensions
-    v = np.random.randint(40,140)
+    v = np.random.randint(40,50)
     n1 = np.random.randint(2,10)
     n2 = np.random.randint(2,10)
-    l1 = np.random.randint(50,100)
-    l2 = np.random.randint(50,100)
+    l1 = np.random.randint(50,60)
+    l2 = np.random.randint(50,60)
 
     # Work out m1 and m2
     m1 = n1*l1
@@ -1941,7 +1941,7 @@ def test_get_dS23D():
             K = ZkjtiVX @ np.linalg.inv(XtiVX) @ L.transpose()
             
             # Sum terms
-            dS2dvechDk = dS2dvechDk + mat2vech2D(np.kron(K,K.transpose()))
+            dS2dvechDk = dS2dvechDk + dupMat2D(nraneffs[k]).toarray().transpose() @ mat2vec2D(np.kron(K,K.transpose()))
 
         # Multiply by sigma^2
         dS2dvechDk = sigma2[testv]*dS2dvechDk
@@ -1998,10 +1998,10 @@ def test_get_InfoMat3D():
 
     # Duplication matrices
     # ------------------------------------------------------------------------------
-    invDupMatdict = dict()
+    dupMatTdict = dict()
     for i in np.arange(len(nraneffs)):
 
-        invDupMatdict[i] = np.asarray(invDupMat2D(nraneffs[i]).todense())
+        dupMatTdict[i] = np.asarray(dupMat2D(nraneffs[i]).todense()).transpose()
 
     # Index variables
     # ------------------------------------------------------------------------------
@@ -2025,7 +2025,7 @@ def test_get_InfoMat3D():
     for k in np.arange(len(nraneffs)):
 
         # Get covariance of dldsigma and dldD      
-        covdldsigmadD = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], invDupMatdict)[0].reshape(FishIndsDk[k+1]-FishIndsDk[k])
+        covdldsigmadD = get_covdldDkdsigma22D(k, sigma2[testv], nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], dupMatTdict)[0].reshape(FishIndsDk[k+1]-FishIndsDk[k])
 
         # Assign to the relevant block
         FI_expected[0, FishIndsDk[k]:FishIndsDk[k+1]] = covdldsigmadD
@@ -2040,7 +2040,7 @@ def test_get_InfoMat3D():
             IndsDk2 = np.arange(FishIndsDk[k2],FishIndsDk[k2+1])
 
             # Get covariance between D_k1 and D_k2 
-            covdldDk1dDk2 = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], invDupMatdict)[0]
+            covdldDk1dDk2 = get_covdldDk1Dk22D(k1, k2, nlevels, nraneffs, ZtZ[0,:,:], DinvIplusZtZD[testv,:,:], dupMatTdict)[0]
 
             # Add to FImat
             FI_expected[np.ix_(IndsDk1, IndsDk2)] = covdldDk1dDk2


### PR DESCRIPTION
This PR resolves an issue unearthed whilst writing the proofs up of the FS algorithm. Demidenko (2013) had given the derivative with respect to vech(D_k) by:

dl/dvech(D_k)=DupMat^+_k*dl/dvec(D_k)

When in fact, as Turkington (2013) gives it, the derivative is:

dl/dvech(D_k)=DupMat'_k*dl/dvec(D_k)

I believe Turkington as writing out the matrix mutliplication we can see clearly that this is just a restatement of the law of total derivatives. When I implemented this in the code it made surprisingly little difference to results but the code ran faster and the ghost overflow/covergence issues experienced before have vanished. 
