### PR TITLE
Batch Y prods

### DIFF
--- a/lib/est3d.py
+++ b/lib/est3d.py
@@ -1404,7 +1404,7 @@ def SFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol,n,
 #                   sigma2, vech(D1),...vech(Dr)) for every voxel.
 #
 # ============================================================================
-def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, n, reml=False):
+def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, n, reml=False, maxnit=10000):
 
     # ------------------------------------------------------------------------------
     # Useful scalars
@@ -1545,6 +1545,16 @@ def pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, 
 
         # Update number of iterations
         nit = nit + 1
+
+        # If we've hit maximum number of iterations halt.
+        if (nit > maxnit):
+
+            # Set tolerance to accept all remaining estimates
+            tol = np.Inf
+
+            # Print warning:
+            print('Maxmimum number of iterations, ' + str(maxnit) + ', reached whilst estimating ' +
+                  str(np.prod(llhprev.shape)) + ' voxels.')
             
         # --------------------------------------------------------------------------
         # Update loglikelihood and number of voxels

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -587,6 +587,8 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
     # Obtain number of voxel batches for parallelization.
     pnvb = pracNumVoxelBlocks(inputs)
 
+    print('pvnb: ', pvnb)
+
     # Get output directory
     OutDir = inputs['outdir']
 

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -254,7 +254,6 @@ def main(*args):
     # is large. We save these "chunk by chunk" as memory map objects just
     # in case they don't fit in working memory (this is only usually a
     # large issue for very large designs).
-    memorySafeAtB(A,B,MAXMEM,prodStr,inputs)
     memorySafeAtB(Z.reshape(1,Z.shape[0],Z.shape[1]),Y,MAXMEM,"ZtY",inputs)
     memorySafeAtB(X.reshape(1,X.shape[0],X.shape[1]),Y,MAXMEM,"XtY",inputs)
     memorySafeAtB(Y,Y,MAXMEM,"YtY",inputs)

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -675,9 +675,9 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
                 if A.shape[0]==1:
-                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                    M[voxelGroups_file[vb],:]=M[voxelGroups_file[vb],:]+(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
                 else:
-                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1)[voxelGroups_orig[vb],:,:] @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                    M[voxelGroups_file[vb],:]=M[voxelGroups_file[vb],:]+(A.transpose(0,2,1)[voxelGroups_orig[vb],:,:] @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
                 
         # Delete M from memory (important!)
         del M

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -606,6 +606,10 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
         # Number of voxels in this batch
         batch_v = len(batch_inds)
 
+        print('batch_v: ', batch_v)
+        print('batch_inds: ', batch_inds)
+        print('voxBatch: ', voxBatch)
+
         # Check if file is in use
         fileLocked = True
         while fileLocked:
@@ -630,12 +634,18 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             # at any one given time.
             vPerBlock = MAXMEM/(10*8*pORq)
 
+            print('vPerBlock: ', vPerBlock)
+            print('batch_v//vPerBlock+1: ', batch_v//vPerBlock+1)
+
             # Work out the indices for each group of voxels
             voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
+
+            print('str: ', prodStr)
 
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
                 M[voxelGroups[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
+                print('voxelGroups[vb]: ', voxelGroups[vb])
         
         # Otherwise we add to the memory map that does exist
         else:
@@ -652,9 +662,11 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             # Work out the indices for each group of voxels
             voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
             
+            print('str: ', prodStr)
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
                 M[voxelGroups[vb],:]=M[voxelGroups[vb],:]+(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
+                print('voxelGroups[vb]: ', voxelGroups[vb])
 
         # Delete M from memory (important!)
         del M

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -620,7 +620,7 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
         if not os.path.isfile(filename):
 
             # Create a memory-mapped .npy file with the dimensions and dtype we want
-            M = open_memmap(filename, mode='w+', dtype='float64', shape=(v,pORq))
+            M = open_memmap(filename, mode='w+', dtype='float64', shape=(batch_v,pORq))
 
             # Work out the number of voxels we can save at a time.
             # (8 bytes per numpy float exponent multiplied by 10
@@ -642,7 +642,7 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
 
             # Load in the file but in memory map mode
             M = np.load(filename,mmap_mode='r+')
-            M = M.reshape((v,pORq))
+            M = M.reshape((batch_v,pORq))
 
             # Work out the number of voxels we can save at a time.
             # (8 bytes per numpy float exponent multiplied by 10

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -595,7 +595,7 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
     pORq = A.shape[2]
 
     # Loop through voxel batches (groups of voxels we wish to partition into)
-    for voxBatch in range(pnvb):
+    for voxBatch in range(int(pnvb)):
 
         # Get filename
         filename = os.path.join(OutDir,"tmp",prodStr + str(voxBatch) + ".npy")

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -587,7 +587,7 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
     # Obtain number of voxel batches for parallelization.
     pnvb = pracNumVoxelBlocks(inputs)
 
-    print('pvnb: ', pvnb)
+    print('pvnb: ', pnvb)
 
     # Get output directory
     OutDir = inputs['outdir']

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -254,9 +254,10 @@ def main(*args):
     # is large. We save these "chunk by chunk" as memory map objects just
     # in case they don't fit in working memory (this is only usually a
     # large issue for very large designs).
-    memorySafeAtB(Z.reshape(1,Z.shape[0],Z.shape[1]),Y,MAXMEM,os.path.join(OutDir,"tmp","ZtY.npy"))
-    memorySafeAtB(X.reshape(1,X.shape[0],X.shape[1]),Y,MAXMEM,os.path.join(OutDir,"tmp","XtY.npy"))
-    memorySafeAtB(Y,Y,MAXMEM,os.path.join(OutDir,"tmp","YtY.npy"))
+    memorySafeAtB(A,B,MAXMEM,prodStr,inputs)
+    memorySafeAtB(Z.reshape(1,Z.shape[0],Z.shape[1]),Y,MAXMEM,"ZtY",inputs)
+    memorySafeAtB(X.reshape(1,X.shape[0],X.shape[1]),Y,MAXMEM,"XtY",inputs)
+    memorySafeAtB(Y,Y,MAXMEM,"YtY",inputs)
 
     # In a spatially varying design XtX has dimensions n by p by p. We
     # reshape to n by p^2 so that we can save as a csv.
@@ -578,69 +579,91 @@ def obtainY(Y_files, M_files, M_t, M_a):
 # - `A`: The (1, k1, k2) shaped matrix.
 # - `B`: The (v, k1, k3) shaped matrix.
 # - `MAXMEM`: The maximum memory allowed for usage, in bytes.
-# - `filename`: The name of the file.
+# - `prodStr`: String representing product matrix i.e. "ZtY", "XtY",... etc.
+# - `inputs`: The inputs structure.
 #
 # ============================================================================
-def memorySafeAtB(A,B,MAXMEM,filename):
+def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
 
-    # Check if file is in use
-    fileLocked = True
-    while fileLocked:
-        try:
-            # Create lock file, so other jobs know we are writing to this file
-            f = os.open(filename + ".lock", os.O_CREAT|os.O_EXCL|os.O_RDWR)
-            fileLocked = False
-        except FileExistsError:
-            fileLocked = True
+    # Obtain number of voxel batches for parallelization.
+    pnvb = pracNumVoxelBlocks(inputs)
+
+    # Get output directory
+    OutDir = inputs['outdir']
 
     # Record v and k3 (which is usually p or q)
     v = B.shape[0]
     pORq = A.shape[2]
 
-    # If the memory map doesn't exist already, create it
-    if not os.path.isfile(filename):
+    # Loop through voxel batches (groups of voxels we wish to partition into)
+    for voxBatch in np.arange(pnvb):
 
-        # Create a memory-mapped .npy file with the dimensions and dtype we want
-        M = open_memmap(filename, mode='w+', dtype='float64', shape=(v,pORq))
+        # Get filename
+        filename = os.path.join(OutDir,"tmp",prodStr + str(voxBatch) + ".npy")
 
-        # Work out the number of voxels we can save at a time.
-        # (8 bytes per numpy float exponent multiplied by 10
-        # for a safe overhead)
-        vPerBlock = MAXMEM/(10*8*pORq)
+        # Get indices for this batch of voxels
+        batch_inds = np.array_split(np.arange(v), pnvb)[voxBatch]
 
-        # Work out the indices for each group of voxels
-        voxelGroups = np.array_split(np.arange(v, dtype='int32'), v//vPerBlock+1)
+        # Number of voxels in this batch
+        batch_v = len(batch_inds)
 
-        # Loop through each group of voxels saving A'B for those voxels
-        for vb in range(int(v//vPerBlock+1)):
-            M[voxelGroups[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
-    
-    # Otherwise we add to the memory map that does exist
-    else:
+        # Check if file is in use
+        fileLocked = True
+        while fileLocked:
+            try:
+                # Create lock file, so other jobs know we are writing to this file
+                f = os.open(filename + ".lock", os.O_CREAT|os.O_EXCL|os.O_RDWR)
+                fileLocked = False
+            except FileExistsError:
+                fileLocked = True
 
-        # Load in the file but in memory map mode
-        M = np.load(filename,mmap_mode='r+')
-        M = M.reshape((v,pORq))
+        # If the memory map doesn't exist already, create it
+        if not os.path.isfile(filename):
 
-        # Work out the number of voxels we can save at a time.
-        # (8 bytes per numpy float exponent multiplied by 10
-        # for a safe overhead)
-        vPerBlock = MAXMEM/(10*8*pORq)
+            # Create a memory-mapped .npy file with the dimensions and dtype we want
+            M = open_memmap(filename, mode='w+', dtype='float64', shape=(v,pORq))
 
-        # Work out the indices for each group of voxels
-        voxelGroups = np.array_split(np.arange(v, dtype='int32'), v//vPerBlock+1)
+            # Work out the number of voxels we can save at a time.
+            # (8 bytes per numpy float exponent multiplied by 10
+            # for a safe overhead). Here we are using batch to describe
+            # the number of voxels we want to save to each file and block
+            # to describe the number of voxels we can actually save to a file
+            # at any one given time.
+            vPerBlock = MAXMEM/(10*8*pORq)
+
+            # Work out the indices for each group of voxels
+            voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
+
+            # Loop through each group of voxels saving A'B for those voxels
+            for vb in range(int(batch_v//vPerBlock+1)):
+                M[voxelGroups[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
         
-        # Loop through each group of voxels saving A'B for those voxels
-        for vb in range(int(v//vPerBlock+1)):
-            M[voxelGroups[vb],:]=M[voxelGroups[vb],:]+(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
+        # Otherwise we add to the memory map that does exist
+        else:
 
-    # Delete M from memory (important!)
-    del M
+            # Load in the file but in memory map mode
+            M = np.load(filename,mmap_mode='r+')
+            M = M.reshape((v,pORq))
 
-    # Delete lock file, so other jobs know they can now write to the
-    # file
-    os.remove(filename + ".lock")
-    os.close(f)
+            # Work out the number of voxels we can save at a time.
+            # (8 bytes per numpy float exponent multiplied by 10
+            # for a safe overhead)
+            vPerBlock = MAXMEM/(10*8*pORq)
+
+            # Work out the indices for each group of voxels
+            voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
+            
+            # Loop through each group of voxels saving A'B for those voxels
+            for vb in range(int(batch_v//vPerBlock+1)):
+                M[voxelGroups[vb],:]=M[voxelGroups[vb],:]+(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
+
+        # Delete M from memory (important!)
+        del M
+
+        # Delete lock file, so other jobs know they can now write to the
+        # file
+        os.remove(filename + ".lock")
+        os.close(f)
 
 if __name__ == "__main__":
     main()

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -607,7 +607,6 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
         batch_v = len(batch_inds)
 
         print('batch_v: ', batch_v)
-        print('batch_inds: ', batch_inds)
         print('voxBatch: ', voxBatch)
 
         # Check if file is in use
@@ -646,10 +645,11 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
 
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
+                print('shape 1: ', A.transpose(0,2,1).shape)
+                print('shape 2: ', B[voxelGroups_orig[vb],:,:].shape)
+                print('shape 3: ',len(voxelGroups_orig[vb]),pORq)
                 M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
-                print('voxelGroups_orig[vb]: ', voxelGroups_orig[vb])
-                print('voxelGroups_file[vb]: ', voxelGroups_file[vb])
-        
+                
         # Otherwise we add to the memory map that does exist
         else:
 
@@ -671,8 +671,6 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
                 M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
-                print('voxelGroups_orig[vb]: ', voxelGroups_orig[vb])
-                print('voxelGroups_file[vb]: ', voxelGroups_file[vb])
 
         # Delete M from memory (important!)
         del M

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -595,7 +595,7 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
     pORq = A.shape[2]
 
     # Loop through voxel batches (groups of voxels we wish to partition into)
-    for voxBatch in np.arange(pnvb):
+    for voxBatch in range(pnvb):
 
         # Get filename
         filename = os.path.join(OutDir,"tmp",prodStr + str(voxBatch) + ".npy")

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -637,15 +637,18 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             print('vPerBlock: ', vPerBlock)
             print('batch_v//vPerBlock+1: ', batch_v//vPerBlock+1)
 
-            # Work out the indices for each group of voxels
-            voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
+            # Work out the indices for each group of voxels for original matrix and
+            # for in file
+            voxelGroups_orig = np.array_split(batch_inds, batch_v//vPerBlock+1) # Indices from original matrix
+            voxelGroups_file = np.array_split(np.arange(batch_v), batch_v//vPerBlock+1) # Indices we write to in file
 
             print('str: ', prodStr)
 
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
-                M[voxelGroups[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
-                print('voxelGroups[vb]: ', voxelGroups[vb])
+                M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                print('voxelGroups_orig[vb]: ', voxelGroups_orig[vb])
+                print('voxelGroups_file[vb]: ', voxelGroups_file[vb])
         
         # Otherwise we add to the memory map that does exist
         else:
@@ -659,14 +662,17 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             # for a safe overhead)
             vPerBlock = MAXMEM/(10*8*pORq)
 
-            # Work out the indices for each group of voxels
-            voxelGroups = np.array_split(batch_inds, batch_v//vPerBlock+1)
+            # Work out the indices for each group of voxels for original matrix and
+            # for in file
+            voxelGroups_orig = np.array_split(batch_inds, batch_v//vPerBlock+1) # Indices from original matrix
+            voxelGroups_file = np.array_split(np.arange(batch_v), batch_v//vPerBlock+1) # Indices we write to in file
             
             print('str: ', prodStr)
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
-                M[voxelGroups[vb],:]=M[voxelGroups[vb],:]+(A.transpose(0,2,1) @ B[voxelGroups[vb],:,:]).reshape(len(voxelGroups[vb]),pORq)
-                print('voxelGroups[vb]: ', voxelGroups[vb])
+                M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                print('voxelGroups_orig[vb]: ', voxelGroups_orig[vb])
+                print('voxelGroups_file[vb]: ', voxelGroups_file[vb])
 
         # Delete M from memory (important!)
         del M

--- a/src/blmm_batch.py
+++ b/src/blmm_batch.py
@@ -648,8 +648,12 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
                 print('shape 1: ', A.transpose(0,2,1).shape)
                 print('shape 2: ', B[voxelGroups_orig[vb],:,:].shape)
                 print('shape 3: ',len(voxelGroups_orig[vb]),pORq)
-                M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                if A.shape[0]==1:
+                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                else:
+                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1)[voxelGroups_orig[vb],:,:] @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
                 
+
         # Otherwise we add to the memory map that does exist
         else:
 
@@ -670,8 +674,11 @@ def memorySafeAtB(A,B,MAXMEM,prodStr,inputs):
             print('str: ', prodStr)
             # Loop through each group of voxels saving A'B for those voxels
             for vb in range(int(batch_v//vPerBlock+1)):
-                M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
-
+                if A.shape[0]==1:
+                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1) @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                else:
+                    M[voxelGroups_file[vb],:]=(A.transpose(0,2,1)[voxelGroups_orig[vb],:,:] @ B[voxelGroups_orig[vb],:,:]).reshape(len(voxelGroups_orig[vb]),pORq)
+                
         # Delete M from memory (important!)
         del M
 

--- a/src/blmm_estimate.py
+++ b/src/blmm_estimate.py
@@ -125,8 +125,13 @@ def main(inputs, inds, XtX, XtY, XtZ, YtX, YtY, YtZ, ZtX, ZtY, ZtZ, n, nlevels, 
         if inputs['sim']:
             t1 = time.time()
 
+    if 'maxnit' in inputs:
+        maxnit = int(inputs['maxnit'])
+    else:
+        maxnit = 10000
+
     if method=='pSFS': # Recommended, default method
-        paramVec = pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, n, reml=REML)
+        paramVec = pSFS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, n, reml=REML, maxnit=maxnit)
     
     if method=='FS': 
         paramVec = FS3D(XtX, XtY, ZtX, ZtY, ZtZ, XtZ, YtZ, YtY, YtX, nlevels, nraneffs, tol, n)

--- a/src/blmm_results.py
+++ b/src/blmm_results.py
@@ -242,9 +242,9 @@ def main(ipath, vb):
         # --------------------------------------------------------------------------------
 
         # Ring X'Y, Y'Y, Z'Y
-        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, p, 1])
-        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, 1, 1])
-        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, q, 1])
+        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb-1)+'.npy'), R_inds_bam).reshape([v_r, p, 1])
+        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb-1)+'.npy'), R_inds_bam).reshape([v_r, 1, 1])
+        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb-1)+'.npy'), R_inds_bam).reshape([v_r, q, 1])
         # XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), R_inds_am).reshape([v_r, p, 1])
         # YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), R_inds_am).reshape([v_r, 1, 1])
         # ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), R_inds_am).reshape([v_r, q, 1])
@@ -253,9 +253,9 @@ def main(ipath, vb):
         # XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), I_inds_am).reshape([v_i, p, 1])
         # YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), I_inds_am).reshape([v_i, 1, 1])
         # ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), I_inds_am).reshape([v_i, q, 1])
-        XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, p, 1])
-        YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, 1, 1])
-        ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, q, 1])
+        XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb-1)+'.npy'), I_inds_bam).reshape([v_i, p, 1])
+        YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb-1)+'.npy'), I_inds_bam).reshape([v_i, 1, 1])
+        ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb-1)+'.npy'), I_inds_bam).reshape([v_i, q, 1])
 
         # Ring Z'Z. Z'X, X'X
         if v_r:

--- a/src/blmm_results.py
+++ b/src/blmm_results.py
@@ -253,9 +253,9 @@ def main(ipath, vb):
         # XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), I_inds_am).reshape([v_i, p, 1])
         # YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), I_inds_am).reshape([v_i, 1, 1])
         # ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), I_inds_am).reshape([v_i, q, 1])
-        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, p, 1])
-        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, 1, 1])
-        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, q, 1])
+        XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, p, 1])
+        YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, 1, 1])
+        ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, q, 1])
 
         # Ring Z'Z. Z'X, X'X
         if v_r:

--- a/src/blmm_results.py
+++ b/src/blmm_results.py
@@ -209,6 +209,9 @@ def main(ipath, vb):
         ix_r = np.argsort(np.argsort(R_inds))
         R_inds_am = np.sort(np.where(np.in1d(amInds,R_inds))[0])[ix_r]
 
+        # In relation to batch analysis mask
+        R_inds_bam = np.sort(np.where(np.in1d(bamInds,R_inds))[0])[ix_r]
+
         # Get indices of the "inner" volume where all studies had information
         # present. I.e. the voxels (usually near the middle of the brain) where
         # every voxel has a reading for every study.
@@ -217,6 +220,9 @@ def main(ipath, vb):
         # Work out the 'inner' indices, in relation to the analysis mask
         ix_i = np.argsort(np.argsort(I_inds))
         I_inds_am = np.sort(np.where(np.in1d(amInds,I_inds))[0])[ix_i]
+
+        # In relation to batch analysis mask
+        I_inds_bam = np.sort(np.where(np.in1d(bamInds,I_inds))[0])[ix_i]
 
         # ------------------------------------------------------------------------
         # Number of voxels in ring and inner
@@ -236,14 +242,20 @@ def main(ipath, vb):
         # --------------------------------------------------------------------------------
 
         # Ring X'Y, Y'Y, Z'Y
-        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), R_inds_am).reshape([v_r, p, 1])
-        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), R_inds_am).reshape([v_r, 1, 1])
-        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), R_inds_am).reshape([v_r, q, 1])
+        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, p, 1])
+        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, 1, 1])
+        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), R_inds_bam).reshape([v_r, q, 1])
+        # XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), R_inds_am).reshape([v_r, p, 1])
+        # YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), R_inds_am).reshape([v_r, 1, 1])
+        # ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), R_inds_am).reshape([v_r, q, 1])
 
         # Inner X'Y, Y'Y, Z'Y
-        XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), I_inds_am).reshape([v_i, p, 1])
-        YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), I_inds_am).reshape([v_i, 1, 1])
-        ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), I_inds_am).reshape([v_i, q, 1])
+        # XtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY.npy'), I_inds_am).reshape([v_i, p, 1])
+        # YtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY.npy'), I_inds_am).reshape([v_i, 1, 1])
+        # ZtY_i = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY.npy'), I_inds_am).reshape([v_i, q, 1])
+        XtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'XtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, p, 1])
+        YtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'YtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, 1, 1])
+        ZtY_r = readLinesFromNPY(os.path.join(OutDir,"tmp",'ZtY'+str(vb)+'.npy'), I_inds_bam).reshape([v_i, q, 1])
 
         # Ring Z'Z. Z'X, X'X
         if v_r:

--- a/src/blmm_results.py
+++ b/src/blmm_results.py
@@ -109,6 +109,7 @@ def main(ipath, vb):
     nraneffs = np.array(nraneffs)
     nlevels = np.array(nlevels)
     q = np.sum(nraneffs*nlevels)
+    q0 = nraneffs[0]
 
     # Get number of unique random effects
     q_u = np.sum(nraneffs*(nraneffs+1)//2)
@@ -180,7 +181,7 @@ def main(ipath, vb):
     # practice). We allow slightly more for the one random factor model
     # since we do not construct any additional q by q matrices.
     if  r == 1:
-        nvb = MAXMEM/(10*4*(q**2))
+        nvb = MAXMEM/(10*8*(q*q0))
     else:
         nvb = MAXMEM/(10*8*(q**2))
     

--- a/src/blmm_results.py
+++ b/src/blmm_results.py
@@ -109,7 +109,6 @@ def main(ipath, vb):
     nraneffs = np.array(nraneffs)
     nlevels = np.array(nlevels)
     q = np.sum(nraneffs*nlevels)
-    q0 = nraneffs[0]
 
     # Get number of unique random effects
     q_u = np.sum(nraneffs*(nraneffs+1)//2)
@@ -181,7 +180,7 @@ def main(ipath, vb):
     # practice). We allow slightly more for the one random factor model
     # since we do not construct any additional q by q matrices.
     if  r == 1:
-        nvb = MAXMEM/(10*8*(q*q0))
+        nvb = MAXMEM/(10*4*(q**2))
     else:
         nvb = MAXMEM/(10*8*(q**2))
     

--- a/src/blmm_setup.py
+++ b/src/blmm_setup.py
@@ -44,7 +44,8 @@ from lib.fileio import loadFile, str2vec, pracNumVoxelBlocks, get_amInds, addBlo
 #                 to users (as we are yet to see a design that really needs it), it is
 #                 very useful when developing code to be able to run small chunks of 
 #                 the brain instead of the whole thing. For this reason it has been 
-#                 left in here.
+#                 left in here. However, it is not maintained, so may need some
+#                 tweaking to use.
 #
 # ====================================================================================
 def main(*args):


### PR DESCRIPTION
This PR includes the following updates:

-  The batch files now output not just to one file for the product matrices Z'Y, X'Y and Y'Y but rather `nvb` files where `nvb` is the number of voxel batches to be run during the next stage. This gives a massive improvement in terms of computation speed as there was a bottleneck where each batch job was having to wait its turn to output to Z'Y for large models.
- An iteration limit has been added in case voxels do not converge.